### PR TITLE
feat: Web3Auth compatibility across all contract writes and auth flows

### DIFF
--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
-import { useAccount } from "wagmi";
+import { useAuth } from "@/hooks/use-auth";
 import { useApolloClient } from "@apollo/client/react";
 import { useIsAdmin } from "@/hooks/use-is-admin";
 import { ConnectorSelectionSheet } from "@/components/connector-selection-sheet";
@@ -247,7 +247,7 @@ function DeluluRow({
 }
 
 export default function AdminDashboardPage() {
-  const { address, isConnected } = useAccount();
+  const { address, isConnected } = useAuth();
   const { theme, toggleTheme } = useTheme();
   const apolloClient = useApolloClient();
   const { isAdmin, isLoading: isAdminLoading } = useIsAdmin();

--- a/apps/web/src/app/admin/users/page.tsx
+++ b/apps/web/src/app/admin/users/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
-import { useAccount } from "wagmi";
+import { useAuth } from "@/hooks/use-auth";
 import { useIsAdmin } from "@/hooks/use-is-admin";
 import { ConnectorSelectionSheet } from "@/components/connector-selection-sheet";
 import {
@@ -114,7 +114,7 @@ function Pagination({
 }
 
 export default function AdminUsersPage() {
-  const { address, isConnected } = useAccount();
+  const { address, isConnected } = useAuth();
   const { theme, toggleTheme } = useTheme();
   const { isAdmin, isLoading: isAdminLoading } = useIsAdmin();
   const {

--- a/apps/web/src/app/daily-claim/DailyClaimClient.tsx
+++ b/apps/web/src/app/daily-claim/DailyClaimClient.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { useAccount, useBalance } from "wagmi";
+import { useBalance } from "wagmi";
+import { useAuth } from "@/hooks/use-auth";
 import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import { ArrowLeft, Wallet, Loader2 } from "lucide-react";
@@ -29,7 +30,7 @@ const FaucetModal = dynamic(
 const IdentityFlow = dynamic(() => import("./IdentityFlow"), { ssr: false });
 
 export default function DailyClaimClient() {
-  const { address, isConnected } = useAccount();
+  const { address, isConnected } = useAuth();
   const router = useRouter();
   const {
     isLoading: isClaimDataLoading,

--- a/apps/web/src/app/daily-claim/verify/page.tsx
+++ b/apps/web/src/app/daily-claim/verify/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Loader2, ExternalLink } from "lucide-react";
-import { useAccount } from "wagmi";
+import { useAuth } from "@/hooks/use-auth";
 import { useIdentity } from "@/hooks/identityHook";
 import { useTokenBalance } from "@/hooks/use-token-balance";
 import { GOODDOLLAR_ADDRESSES } from "@/lib/constant";
@@ -11,7 +11,7 @@ import { GOODDOLLAR_ADDRESSES } from "@/lib/constant";
 export default function VerifyGoodDollarPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { isConnected } = useAccount();
+  const { isConnected } = useAuth();
   const { status, isVerified, fvLink, setIsVerifying } = useIdentity();
   const { formatted: gDollarBalance, isLoading: isGdLoading } = useTokenBalance(
     GOODDOLLAR_ADDRESSES.mainnet,

--- a/apps/web/src/app/delulu/[id]/page.tsx
+++ b/apps/web/src/app/delulu/[id]/page.tsx
@@ -5,12 +5,11 @@ import { useRouter, useParams, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import { SharesSheet } from "@/components/shares-sheet";
 import {
-  useAccount,
   useChainId,
   useReadContract,
-  useWriteContract,
   useWaitForTransactionReceipt,
 } from "wagmi";
+import { useUnifiedWriteContract } from "@/hooks/use-unified-write-contract";
 import { useAuth } from "@/hooks/use-auth";
 import { useQueryClient } from "@tanstack/react-query";
 import { useApolloClient } from "@apollo/client/react";
@@ -500,7 +499,7 @@ export default function DeluluPage() {
     data: addMilestonesHash,
     isPending: isAddingMilestones,
     error: addMilestonesError,
-  } = useWriteContract();
+  } = useUnifiedWriteContract();
   const {
     isLoading: isConfirmingAddMilestones,
     isSuccess: isAddMilestonesSuccess,
@@ -510,7 +509,7 @@ export default function DeluluPage() {
     data: submitMilestoneHash,
     isPending: isSubmittingMilestone,
     error: submitMilestoneError,
-  } = useWriteContract();
+  } = useUnifiedWriteContract();
   const {
     isLoading: isConfirmingSubmitMilestone,
     isSuccess: isSubmitMilestoneSuccess,
@@ -520,7 +519,7 @@ export default function DeluluPage() {
     data: resetMilestonesHash,
     isPending: isResettingMilestones,
     error: resetMilestonesError,
-  } = useWriteContract();
+  } = useUnifiedWriteContract();
   const {
     isLoading: isConfirmingResetMilestones,
     isSuccess: isResetMilestonesSuccess,
@@ -530,7 +529,7 @@ export default function DeluluPage() {
     data: deleteMilestoneHash,
     isPending: isDeletingMilestone,
     error: deleteMilestoneError,
-  } = useWriteContract();
+  } = useUnifiedWriteContract();
   const {
     isLoading: isConfirmingDeleteMilestone,
     isSuccess: isDeleteMilestoneSuccess,

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { useChainId } from "wagmi";
-import { useAccount } from "wagmi";
+import { useAuth } from "@/hooks/use-auth";
 import { useDeluluLeaderboard } from "@/hooks/graph/useDeluluLeaderboard";
 import { useAllUsersLeaderboard } from "@/hooks/graph/useAllUsersLeaderboard";
 import { useGoodDollarTotalSupply } from "@/hooks/use-gooddollar-total-supply";
@@ -47,7 +47,7 @@ function formatTitle(entry: DeluluLeaderboardEntry) {
 
 function CampaignLeaderboard() {
   const [page, setPage] = useState(0);
-  const { address } = useAccount();
+  const { address } = useAuth();
   const { entries, allEntries, hasNextPage, isLoading, error, refetch } = useDeluluLeaderboard(PAGE_SIZE, page);
   const rangeStart = page * PAGE_SIZE + 1;
   const rangeEnd = page * PAGE_SIZE + entries.length;
@@ -57,7 +57,10 @@ function CampaignLeaderboard() {
     ? allEntries.find((e) => e.creatorAddress.toLowerCase() === address.toLowerCase()) ?? null
     : null;
   const myRank = myEntry ? allEntries.indexOf(myEntry) + 1 : null;
-  const showPinnedMe = myEntry && myRank;
+  const isOnCurrentPage = !!address && entries.some(
+    (e) => e.creatorAddress.toLowerCase() === address.toLowerCase()
+  );
+  const showPinnedMe = myEntry && myRank && !isOnCurrentPage;
 
   if (isLoading) return <SkeletonRows />;
 
@@ -157,7 +160,7 @@ function CampaignLeaderboard() {
 
 function DreamersLeaderboard() {
   const [page, setPage] = useState(0);
-  const { address } = useAccount();
+  const { address } = useAuth();
   const { entries, hasNextPage, hasPrevPage, isLoading, totalCount, isRankLoading, myRankEntry, myPageEntry, error, refetch } =
     useAllUsersLeaderboard(page, address);
 
@@ -178,7 +181,10 @@ function DreamersLeaderboard() {
     <EmptyState message="No dreamers yet." />
   );
 
-  const showPinnedMe = address && myRankEntry;
+  const isOnCurrentPage = !!address && entries.some(
+    (e) => e.address.toLowerCase() === address.toLowerCase()
+  );
+  const showPinnedMe = address && myRankEntry && !isOnCurrentPage;
 
   return (
     <div className="space-y-4">

--- a/apps/web/src/app/sign-in/page.tsx
+++ b/apps/web/src/app/sign-in/page.tsx
@@ -9,11 +9,24 @@ import { DELULU_CONTRACT_ADDRESS } from "@/lib/constant";
 import { useAuth } from "@/hooks/use-auth";
 import { usePrivy } from "@privy-io/react-auth";
 
+const LAST_PROVIDER_KEY = "delulu:last_provider";
+
 export default function SignInPage() {
   const { authenticated, isReady, address, login } = useAuth();
 
-
   const { login: privyLogin } = usePrivy();
+
+  const handleReturningUser = () => {
+    let lastProvider = "privy";
+    try {
+      lastProvider = localStorage.getItem(LAST_PROVIDER_KEY) ?? "privy";
+    } catch {}
+    if (lastProvider === "web3auth") {
+      login();
+    } else {
+      privyLogin({ disableSignup: true });
+    }
+  };
   const router = useRouter();
 
   const { data: existingUsername, isSuccess, isError } = useReadContract({
@@ -107,9 +120,9 @@ export default function SignInPage() {
             Get Started
           </button>
 
-          {/* Returning users → Privy modal (all pre-Web3Auth accounts are Privy) */}
+          {/* Returning users → opens the provider they last used */}
           <button
-            onClick={() => privyLogin()}
+            onClick={handleReturningUser}
             className="w-full flex items-center justify-center gap-2.5 py-4 rounded-2xl
               bg-transparent text-foreground font-bold text-base
               border-2 border-border

--- a/apps/web/src/components/ai-milestones-modal.tsx
+++ b/apps/web/src/components/ai-milestones-modal.tsx
@@ -2,11 +2,8 @@
 
 import { useState, useEffect, useCallback } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import {
-  useWriteContract,
-  useWaitForTransactionReceipt,
-  useChainId,
-} from "wagmi";
+import { useWaitForTransactionReceipt, useChainId } from "wagmi";
+import { useUnifiedWriteContract } from "@/hooks/use-unified-write-contract";
 import { Loader2, X, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DELULU_ABI } from "@/lib/abi";
@@ -55,7 +52,7 @@ export function AiMilestonesModal({
     isPending,
     error: writeError,
     reset,
-  } = useWriteContract();
+  } = useUnifiedWriteContract();
   const { isLoading: isConfirming, isSuccess } =
     useWaitForTransactionReceipt({ hash });
 

--- a/apps/web/src/components/continue-journey-card.tsx
+++ b/apps/web/src/components/continue-journey-card.tsx
@@ -14,7 +14,7 @@ const CATEGORY_ICONS: Record<string, LucideIcon> = {
   mindset:   Brain,
   other:     Target,
 };
-import { useAccount } from "wagmi";
+import { useAuth } from "@/hooks/use-auth";
 import { cn } from "@/lib/utils";
 import {
   useGoalSeries,
@@ -55,7 +55,7 @@ interface ContinueJourneyCardProps {
 }
 
 export function ContinueJourneyCard({ className }: ContinueJourneyCardProps) {
-  const { address } = useAccount();
+  const { address } = useAuth();
   const router = useRouter();
   const { data: series, isLoading } = useGoalSeries(address);
   const [showAbandonModal, setShowAbandonModal] = useState(false);

--- a/apps/web/src/components/create-delusion-content.tsx
+++ b/apps/web/src/components/create-delusion-content.tsx
@@ -39,7 +39,8 @@ import { TokenBadge } from "@/components/token-badge";
 import { useSupportedTokens } from "@/hooks/use-supported-tokens";
 import { GOODDOLLAR_ADDRESSES, TOKEN_LOGOS } from "@/lib/constant";
 import { useGoodDollarPrice } from "@/hooks/use-gooddollar-price";
-import { useAccount, useBalance } from "wagmi";
+import { useBalance } from "wagmi";
+import { useAuth } from "@/hooks/use-auth";
 import { cn } from "@/lib/utils";
 import { DateTimePicker } from "@/components/date-time-picker";
 import { CELO_MAINNET_ID } from "@/lib/constant";
@@ -212,7 +213,7 @@ export function CreateDelusionContent({ onClose }: CreateDelusionContentProps) {
   const [selectedToken, setSelectedToken] = useState<string>(initialToken);
   const [isTokenDropdownOpen, setIsTokenDropdownOpen] = useState(false);
   const tokenDropdownRef = useRef<HTMLDivElement>(null);
-  const { address, isConnected } = useAccount();
+  const { address, isConnected } = useAuth();
   const [inputText, setInputText] = useState<string>("");
   const [stakeInputTouched, setStakeInputTouched] = useState(false);
   const [submitAttempted, setSubmitAttempted] = useState(false);

--- a/apps/web/src/components/delulu-card.tsx
+++ b/apps/web/src/components/delulu-card.tsx
@@ -10,7 +10,7 @@ import { useUsernameByAddress } from "@/hooks/use-username-by-address";
 import { Plus, Flame, Clock, Bell, DollarSign } from "lucide-react";
 import { useApolloClient } from "@apollo/client/react";
 import { GET_DELULU_BY_ID, useGraphDelulu } from "@/hooks/graph/useGraphDelulu";
-import { useAccount } from "wagmi";
+import { useAuth } from "@/hooks/use-auth";
 import { isDeluluCreator } from "@/lib/delulu-utils";
 import {
   getMilestoneEndTimeMs,
@@ -140,7 +140,7 @@ export function DeluluCard({
     ? false
     : isMilestonesLoading;
 
-  const { address } = useAccount();
+  const { address } = useAuth();
   const isCreator = isDeluluCreator(address, delusion);
   const router = useRouter();
   const apolloClient = useApolloClient();

--- a/apps/web/src/components/ongoing-milestones-section.tsx
+++ b/apps/web/src/components/ongoing-milestones-section.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
-import { useWriteContract, useWaitForTransactionReceipt, useChainId } from "wagmi";
+import { useWaitForTransactionReceipt, useChainId } from "wagmi";
+import { useUnifiedWriteContract } from "@/hooks/use-unified-write-contract";
 import { Clock, ChevronRight, FileCheck, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatMilestoneCountdown } from "@/lib/milestone-utils";
@@ -66,7 +67,7 @@ export function OngoingMilestonesSection({ onCreateClick }: OngoingMilestonesSec
     isPending: isSubmittingMilestone,
     error: submitMilestoneError,
     reset: resetSubmit,
-  } = useWriteContract();
+  } = useUnifiedWriteContract();
 
   const { isLoading: isConfirming, isSuccess: isSubmitSuccess } =
     useWaitForTransactionReceipt({ hash: submitHash });

--- a/apps/web/src/components/shares-sheet.tsx
+++ b/apps/web/src/components/shares-sheet.tsx
@@ -8,8 +8,8 @@ import {
   useReadContract,
   useWaitForTransactionReceipt,
   useBalance,
-  useWriteContract,
 } from "wagmi";
+import { useUnifiedWriteContract } from "@/hooks/use-unified-write-contract";
 import { useAuth } from "@/hooks/use-auth";
 import { DELULU_ABI } from "@/lib/abi";
 import { getDeluluContractAddress, KNOWN_TOKEN_SYMBOLS } from "@/lib/constant";
@@ -120,7 +120,7 @@ export function SharesSheet({
     return needsApproval(maxCostWithSlippageNum);
   }, [mode, curve, maxCostWithSlippageNum, needsApproval]);
 
-  const { writeContractAsync } = useWriteContract();
+  const { writeContractAsync } = useUnifiedWriteContract();
   const [hash, setHash] = useState<`0x${string}` | undefined>(undefined);
   const [isPending, setIsPending] = useState(false);
   const { isLoading: isConfirming, isSuccess } = useWaitForTransactionReceipt({ hash });

--- a/apps/web/src/hooks/identityHook.ts
+++ b/apps/web/src/hooks/identityHook.ts
@@ -1,16 +1,18 @@
 "use client";
 
 import { useEffect, useState, useMemo } from "react";
-import { useAccount, usePublicClient, useWalletClient } from "wagmi";
+import { usePublicClient } from "wagmi";
 import { useIdentitySDK, IdentitySDK } from "@goodsdks/identity-sdk";
 import { ClaimSDK } from "@goodsdks/citizen-sdk";
+import { useAuth } from "@/hooks/use-auth";
+import { useUnifiedWalletClient } from "@/hooks/use-unified-wallet-client";
 
 export type IdentityStatus = "loading" | "verified" | "not_verified" | "error";
 
 export function useIdentity() {
-  const { address } = useAccount();
+  const { address } = useAuth();
   const publicClient = usePublicClient();
-  const { data: walletClient } = useWalletClient();
+  const walletClient = useUnifiedWalletClient();
   const identitySDK = useIdentitySDK("production");
 
   const [status, setStatus] = useState<IdentityStatus>("loading");

--- a/apps/web/src/hooks/use-allocate-points.ts
+++ b/apps/web/src/hooks/use-allocate-points.ts
@@ -1,9 +1,10 @@
 "use client";
 
-import { useWriteContract, useWaitForTransactionReceipt, useChainId } from "wagmi";
+import { useWaitForTransactionReceipt, useChainId } from "wagmi";
 import { getDeluluContractAddress } from "@/lib/constant";
 import { DELULU_ABI } from "@/lib/abi";
 import { parseUnits } from "viem";
+import { useUnifiedWriteContract } from "@/hooks/use-unified-write-contract";
 
 export function useAllocatePoints() {
   const chainId = useChainId();
@@ -12,7 +13,7 @@ export function useAllocatePoints() {
     data: hash,
     isPending: isAllocating,
     error: allocateError,
-  } = useWriteContract();
+  } = useUnifiedWriteContract();
 
   const {
     isLoading: isConfirming,

--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAccount, useDisconnect } from "wagmi";
 import { usePrivy, useWallets } from "@privy-io/react-auth";
 import {
@@ -12,6 +12,8 @@ import {
 export type AuthProvider = "privy" | "web3auth" | null;
 
 const PROVIDER_KEY = "delulu:auth_provider";
+// Never cleared on logout — used by sign-in page to open the right modal for returning users.
+const LAST_PROVIDER_KEY = "delulu:last_provider";
 
 export interface UseAuthReturn {
   address: `0x${string}` | undefined;
@@ -45,16 +47,39 @@ export function useAuth(): UseAuthReturn {
 
   if (initError) console.error("[auth] web3auth init error:", initError);
 
+  // ── Resolve Web3Auth address directly from its provider ───────────────────
+  // We don't rely on wagmi here — web3Auth.provider is the EIP-1193 source of truth.
+  const [web3authAddress, setWeb3authAddress] = useState<`0x${string}` | undefined>();
+
+  useEffect(() => {
+    if (!web3authConnected || !web3Auth?.provider) {
+      setWeb3authAddress(undefined);
+      return;
+    }
+    (web3Auth.provider as any)
+      .request({ method: "eth_accounts" })
+      .then((accounts: string[]) => {
+        if (accounts?.[0]) setWeb3authAddress(accounts[0] as `0x${string}`);
+      })
+      .catch(() => {});
+  }, [web3authConnected, web3Auth]);
+
   // ── Persist active provider to localStorage on auth state change ──────────
   useEffect(() => {
     if (privyAuthenticated) {
-      try { localStorage.setItem(PROVIDER_KEY, "privy"); } catch {}
+      try {
+        localStorage.setItem(PROVIDER_KEY, "privy");
+        localStorage.setItem(LAST_PROVIDER_KEY, "privy");
+      } catch {}
     }
   }, [privyAuthenticated]);
 
   useEffect(() => {
     if (web3authConnected) {
-      try { localStorage.setItem(PROVIDER_KEY, "web3auth"); } catch {}
+      try {
+        localStorage.setItem(PROVIDER_KEY, "web3auth");
+        localStorage.setItem(LAST_PROVIDER_KEY, "web3auth");
+      } catch {}
     }
   }, [web3authConnected]);
 
@@ -65,6 +90,7 @@ export function useAuth(): UseAuthReturn {
 
   const address: `0x${string}` | undefined =
     account.address ??
+    web3authAddress ??
     (wallets?.[0]?.address as `0x${string}` | undefined) ??
     privyEmbeddedAddress;
 
@@ -77,7 +103,6 @@ export function useAuth(): UseAuthReturn {
     ? "web3auth"
     : null;
 
-  // Privy ready is enough to show the UI — Web3Auth initialization is non-blocking
   const isReady = ready;
 
   // ── Email resolution ──────────────────────────────────────────────────────
@@ -109,7 +134,7 @@ export function useAuth(): UseAuthReturn {
     });
   };
 
-  // ── Logout — reads localStorage so it works after a page refresh ──────────
+  // ── Logout ────────────────────────────────────────────────────────────────
   const logout = async () => {
     let storedProvider: AuthProvider = null;
     try {
@@ -129,6 +154,7 @@ export function useAuth(): UseAuthReturn {
     }
 
     try { localStorage.removeItem(PROVIDER_KEY); } catch {}
+    setWeb3authAddress(undefined);
     disconnect();
   };
 

--- a/apps/web/src/hooks/use-cancel-delulu.ts
+++ b/apps/web/src/hooks/use-cancel-delulu.ts
@@ -1,10 +1,11 @@
-import { useWriteContract, useWaitForTransactionReceipt, useChainId } from "wagmi";
+import { useWaitForTransactionReceipt, useChainId } from "wagmi";
 import { getDeluluContractAddress } from "@/lib/constant";
 import { DELULU_ABI } from "@/lib/abi";
+import { useUnifiedWriteContract } from "@/hooks/use-unified-write-contract";
 
 export function useCancelDelulu() {
   const chainId = useChainId();
-  const { writeContract, data: hash, isPending, error } = useWriteContract();
+  const { writeContract, data: hash, isPending, error } = useUnifiedWriteContract();
   const {
     isLoading: isConfirming,
     isSuccess,

--- a/apps/web/src/hooks/use-claim-winnings.ts
+++ b/apps/web/src/hooks/use-claim-winnings.ts
@@ -1,11 +1,12 @@
-import { useWaitForTransactionReceipt, useChainId, useWriteContract } from "wagmi";
+import { useWaitForTransactionReceipt, useChainId } from "wagmi";
 import { useState } from "react";
 import { getDeluluContractAddress } from "@/lib/constant";
 import { DELULU_ABI } from "@/lib/abi";
+import { useUnifiedWriteContract } from "@/hooks/use-unified-write-contract";
 
 export function useClaimWinnings() {
   const chainId = useChainId();
-  const { writeContractAsync } = useWriteContract();
+  const { writeContractAsync } = useUnifiedWriteContract();
   const [hash, setHash] = useState<`0x${string}` | undefined>(undefined);
   const [isPending, setIsPending] = useState(false);
   const [writeError, setWriteError] = useState<Error | null>(null);

--- a/apps/web/src/hooks/use-create-challenge.ts
+++ b/apps/web/src/hooks/use-create-challenge.ts
@@ -1,16 +1,13 @@
-import {
-  useWriteContract,
-  useWaitForTransactionReceipt,
-} from "wagmi";
-import { useChainId } from "wagmi";
+import { useWaitForTransactionReceipt, useChainId } from "wagmi";
 import { parseUnits } from "viem";
 import { getDeluluContractAddress } from "@/lib/constant";
 import { DELULU_ABI } from "@/lib/abi";
 import { decodeErrorResult } from "viem";
+import { useUnifiedWriteContract } from "@/hooks/use-unified-write-contract";
 
 export function useCreateChallenge() {
   const chainId = useChainId();
-  const { writeContract, data: hash, isPending, error } = useWriteContract();
+  const { writeContract, data: hash, isPending, error } = useUnifiedWriteContract();
 
   const {
     isLoading: isConfirming,

--- a/apps/web/src/hooks/use-delulu-contract.ts
+++ b/apps/web/src/hooks/use-delulu-contract.ts
@@ -3,7 +3,9 @@ import {
   useWriteContract,
 } from "wagmi";
 import { useChainId } from "wagmi";
-import { parseUnits, parseEventLogs } from "viem";
+import { parseUnits, parseEventLogs, createWalletClient, custom } from "viem";
+import { celo } from "wagmi/chains";
+import { getWeb3AuthProvider } from "@/lib/web3auth-bridge";
 import { useState, useMemo } from "react";
 import { getDeluluContractAddress, isGoodDollarToken, isGoodDollarSupported } from "@/lib/constant";
 import { DELULU_ABI } from "@/lib/abi";
@@ -130,18 +132,45 @@ export function useCreateDelulu() {
 
       setIsPending(true);
       setWriteError(null);
-      const txHash = await writeContractAsync({
-        address: contractAddress,
-        abi: DELULU_ABI,
-        functionName: "createDelulu",
-        args: [
-          tokenAddress as `0x${string}`,
-          contentHash,
-          stakingDeadline,
-          resolutionDeadline,
-          initialSupportWei,
-        ],
-      });
+
+      const w3aProvider = getWeb3AuthProvider();
+      let txHash: `0x${string}`;
+
+      if (w3aProvider) {
+        const walletClient = createWalletClient({
+          chain: celo,
+          transport: custom(w3aProvider),
+        });
+        const [account] = await walletClient.getAddresses();
+        txHash = await walletClient.writeContract({
+          address: contractAddress,
+          abi: DELULU_ABI,
+          functionName: "createDelulu",
+          args: [
+            tokenAddress as `0x${string}`,
+            contentHash,
+            stakingDeadline,
+            resolutionDeadline,
+            initialSupportWei,
+          ],
+          account,
+          chain: celo,
+        });
+      } else {
+        txHash = await writeContractAsync({
+          address: contractAddress,
+          abi: DELULU_ABI,
+          functionName: "createDelulu",
+          args: [
+            tokenAddress as `0x${string}`,
+            contentHash,
+            stakingDeadline,
+            resolutionDeadline,
+            initialSupportWei,
+          ],
+        });
+      }
+
       setHash(txHash);
     } catch (error) {
       setWriteError(error instanceof Error ? error : new Error(String(error)));

--- a/apps/web/src/hooks/use-join-challenge.ts
+++ b/apps/web/src/hooks/use-join-challenge.ts
@@ -1,8 +1,9 @@
 "use client";
 
-import { useWriteContract, useWaitForTransactionReceipt, useChainId } from "wagmi";
+import { useWaitForTransactionReceipt, useChainId } from "wagmi";
 import { getDeluluContractAddress } from "@/lib/constant";
 import { DELULU_ABI } from "@/lib/abi";
+import { useUnifiedWriteContract } from "@/hooks/use-unified-write-contract";
 
 export function useJoinChallenge() {
   const chainId = useChainId();
@@ -12,7 +13,7 @@ export function useJoinChallenge() {
     data: hash,
     isPending: isJoining,
     error: joinError,
-  } = useWriteContract();
+  } = useUnifiedWriteContract();
 
   const {
     isLoading: isConfirming,

--- a/apps/web/src/hooks/use-milestone-verification.ts
+++ b/apps/web/src/hooks/use-milestone-verification.ts
@@ -1,17 +1,14 @@
 "use client";
 
-import {
-  useWriteContract,
-  useWaitForTransactionReceipt,
-  useChainId,
-} from "wagmi";
+import { useWaitForTransactionReceipt, useChainId } from "wagmi";
 import { getDeluluContractAddress } from "@/lib/constant";
 import { DELULU_ABI } from "@/lib/abi";
+import { useUnifiedWriteContract } from "@/hooks/use-unified-write-contract";
 
 export function useMilestoneVerification() {
   const chainId = useChainId();
   const { writeContract, data: hash, isPending, error, reset } =
-    useWriteContract();
+    useUnifiedWriteContract();
   const {
     isLoading: isConfirming,
     isSuccess,

--- a/apps/web/src/hooks/use-pfp-upload.ts
+++ b/apps/web/src/hooks/use-pfp-upload.ts
@@ -2,7 +2,7 @@
 
 import { useState, useRef } from "react";
 import { useUserStore } from "@/stores/useUserStore";
-import { useAccount } from "wagmi";
+import { useAuth } from "@/hooks/use-auth";
 import { invalidatePfpCache } from "@/hooks/use-profile-pfp";
 
 export interface UsePfpUploadReturn {
@@ -16,7 +16,7 @@ export interface UsePfpUploadReturn {
 
 export function usePfpUpload(): UsePfpUploadReturn {
   const { updateProfile } = useUserStore();
-  const { address } = useAccount();
+  const { address } = useAuth();
   const [isUploading, setIsUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);

--- a/apps/web/src/hooks/use-resolve-delulu.ts
+++ b/apps/web/src/hooks/use-resolve-delulu.ts
@@ -1,11 +1,12 @@
-import { useWriteContract, useWaitForTransactionReceipt, useChainId } from "wagmi";
+import { useWaitForTransactionReceipt, useChainId } from "wagmi";
 import { getDeluluContractAddress } from "@/lib/constant";
 import { DELULU_ABI } from "@/lib/abi";
 import { decodeErrorResult } from "viem";
+import { useUnifiedWriteContract } from "@/hooks/use-unified-write-contract";
 
 export function useResolveDelulu() {
   const chainId = useChainId();
-  const { writeContract, data: hash, isPending, error } = useWriteContract();
+  const { writeContract, data: hash, isPending, error } = useUnifiedWriteContract();
   const {
     isLoading: isConfirming,
     isSuccess,

--- a/apps/web/src/hooks/use-set-profile.ts
+++ b/apps/web/src/hooks/use-set-profile.ts
@@ -4,9 +4,11 @@ import {
   useWriteContract,
 } from "wagmi";
 import { useState } from "react";
+import { createWalletClient, custom, decodeErrorResult } from "viem";
+import { celo } from "wagmi/chains";
 import { getDeluluContractAddress } from "@/lib/constant";
 import { DELULU_ABI } from "@/lib/abi";
-import { decodeErrorResult } from "viem";
+import { getWeb3AuthProvider } from "@/lib/web3auth-bridge";
 
 export function useSetProfile() {
   const chainId = useChainId();
@@ -28,12 +30,37 @@ export function useSetProfile() {
     try {
       setIsPending(true);
       setWriteError(null);
-      const txHash = await writeContractAsync({
-        address: getDeluluContractAddress(chainId),
-        abi: DELULU_ABI,
-        functionName: "setProfile",
-        args: [username.trim()],
-      });
+
+      const w3aProvider = getWeb3AuthProvider();
+
+      let txHash: `0x${string}`;
+
+      if (w3aProvider) {
+        // Web3Auth path — wagmi has no wallet client for this user,
+        // so write directly via viem using the Web3Auth EIP-1193 provider.
+        const walletClient = createWalletClient({
+          chain: celo,
+          transport: custom(w3aProvider),
+        });
+        const [account] = await walletClient.getAddresses();
+        txHash = await walletClient.writeContract({
+          address: getDeluluContractAddress(chainId),
+          abi: DELULU_ABI,
+          functionName: "setProfile",
+          args: [username.trim()],
+          account,
+          chain: celo,
+        });
+      } else {
+        // Privy / Farcaster path — wagmi connector is connected normally.
+        txHash = await writeContractAsync({
+          address: getDeluluContractAddress(chainId),
+          abi: DELULU_ABI,
+          functionName: "setProfile",
+          args: [username.trim()],
+        });
+      }
+
       setHash(txHash);
     } catch (err) {
       const formatted = formatErrorForDisplay(err);

--- a/apps/web/src/hooks/use-token-approval.ts
+++ b/apps/web/src/hooks/use-token-approval.ts
@@ -1,9 +1,11 @@
 "use client";
 
-import { useWaitForTransactionReceipt, useReadContract, useAccount, useChainId, useWriteContract } from "wagmi";
+import { useWaitForTransactionReceipt, useReadContract, useChainId } from "wagmi";
 import { parseUnits } from "viem";
 import { useState } from "react";
 import { getDeluluContractAddress } from "@/lib/constant";
+import { useAuth } from "@/hooks/use-auth";
+import { useUnifiedWriteContract } from "@/hooks/use-unified-write-contract";
 
 const ERC20_ABI = [
   {
@@ -30,10 +32,10 @@ const ERC20_ABI = [
 
 /** Per-market token approval. Pass the market's token address. */
 export function useTokenApproval(tokenAddress: string | undefined) {
-  const { address } = useAccount();
+  const { address } = useAuth();
   const chainId = useChainId();
   const token = tokenAddress as `0x${string}` | undefined;
-  const { writeContractAsync } = useWriteContract();
+  const { writeContractAsync } = useUnifiedWriteContract();
 
   const [hash, setHash] = useState<`0x${string}` | undefined>(undefined);
   const [isPending, setIsPending] = useState(false);

--- a/apps/web/src/hooks/use-token-balance.ts
+++ b/apps/web/src/hooks/use-token-balance.ts
@@ -1,11 +1,13 @@
 "use client";
 
-import { useAccount, useBalance } from "wagmi";
+import { useBalance, useChainId } from "wagmi";
 import { getAddress } from "viem";
 import { CELO_MAINNET_ID } from "@/lib/constant";
+import { useAuth } from "@/hooks/use-auth";
 
 export function useTokenBalance(tokenAddress: string | undefined) {
-  const { address, chainId } = useAccount();
+  const { address } = useAuth();
+  const chainId = useChainId();
 
   const isMainnet = chainId === CELO_MAINNET_ID;
 

--- a/apps/web/src/hooks/use-unified-wallet-client.ts
+++ b/apps/web/src/hooks/use-unified-wallet-client.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useWalletClient } from "wagmi";
+import { createWalletClient, custom } from "viem";
+import { celo } from "wagmi/chains";
+import { getWeb3AuthProvider } from "@/lib/web3auth-bridge";
+import { useMemo } from "react";
+
+/**
+ * Returns a viem WalletClient for both Privy (wagmi) and Web3Auth users.
+ * Privy users get the wagmi-managed wallet client.
+ * Web3Auth users get a viem client built from the Web3Auth EIP-1193 provider.
+ */
+export function useUnifiedWalletClient() {
+  const { data: wagmiWalletClient } = useWalletClient();
+
+  const web3authClient = useMemo(() => {
+    if (wagmiWalletClient) return null;
+    const w3aProvider = getWeb3AuthProvider();
+    if (!w3aProvider) return null;
+    return createWalletClient({ chain: celo, transport: custom(w3aProvider) });
+  }, [wagmiWalletClient]);
+
+  return wagmiWalletClient ?? web3authClient ?? null;
+}

--- a/apps/web/src/hooks/use-unified-write-contract.ts
+++ b/apps/web/src/hooks/use-unified-write-contract.ts
@@ -1,0 +1,102 @@
+"use client";
+
+import { useWriteContract } from "wagmi";
+import { createWalletClient, custom, type Abi } from "viem";
+import { celo } from "wagmi/chains";
+import { getWeb3AuthProvider } from "@/lib/web3auth-bridge";
+import { useState, useCallback } from "react";
+
+type WriteContractParams = {
+  address: `0x${string}`;
+  abi: Abi | readonly unknown[];
+  functionName: string;
+  args?: readonly unknown[];
+};
+
+/**
+ * Drop-in replacement for wagmi's useWriteContract that works for both
+ * Privy (wagmi connector) and Web3Auth (viem direct) users.
+ *
+ * Returns the same shape as wagmi's useWriteContract:
+ *   { writeContract, writeContractAsync, data, isPending, error, reset }
+ */
+export function useUnifiedWriteContract() {
+  const {
+    writeContractAsync: wagmiWriteAsync,
+    isPending: wagmiIsPending,
+    reset: wagmiReset,
+  } = useWriteContract();
+
+  const [hash, setHash] = useState<`0x${string}` | undefined>(undefined);
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const writeContractAsync = useCallback(
+    async (params: WriteContractParams): Promise<`0x${string}`> => {
+      setError(null);
+      const w3aProvider = getWeb3AuthProvider();
+
+      if (w3aProvider) {
+        setIsPending(true);
+        try {
+          const walletClient = createWalletClient({
+            chain: celo,
+            transport: custom(w3aProvider),
+          });
+          const [account] = await walletClient.getAddresses();
+          const txHash = await walletClient.writeContract({
+            ...(params as Parameters<typeof walletClient.writeContract>[0]),
+            account,
+            chain: celo,
+          });
+          setHash(txHash);
+          return txHash;
+        } catch (err) {
+          const e = err instanceof Error ? err : new Error(String(err));
+          setError(e);
+          throw e;
+        } finally {
+          setIsPending(false);
+        }
+      } else {
+        setIsPending(true);
+        try {
+          const txHash = await wagmiWriteAsync(
+            params as Parameters<typeof wagmiWriteAsync>[0]
+          );
+          setHash(txHash);
+          return txHash;
+        } catch (err) {
+          const e = err instanceof Error ? err : new Error(String(err));
+          setError(e);
+          throw e;
+        } finally {
+          setIsPending(false);
+        }
+      }
+    },
+    [wagmiWriteAsync]
+  );
+
+  const writeContract = useCallback(
+    (params: WriteContractParams) => {
+      writeContractAsync(params).catch(() => {});
+    },
+    [writeContractAsync]
+  );
+
+  const reset = useCallback(() => {
+    setHash(undefined);
+    setError(null);
+    wagmiReset();
+  }, [wagmiReset]);
+
+  return {
+    writeContract,
+    writeContractAsync,
+    data: hash,
+    isPending: isPending || wagmiIsPending,
+    error,
+    reset,
+  };
+}

--- a/apps/web/src/hooks/useGoodDollarClaim.ts
+++ b/apps/web/src/hooks/useGoodDollarClaim.ts
@@ -1,7 +1,9 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef } from "react";
-import { useAccount, usePublicClient, useWalletClient } from "wagmi";
+import { usePublicClient } from "wagmi";
+import { useAuth } from "@/hooks/use-auth";
+import { useUnifiedWalletClient } from "@/hooks/use-unified-wallet-client";
 
 let ClaimSDK: any;
 let useIdentitySDK: any;
@@ -43,9 +45,9 @@ export interface UseGoodDollarClaimReturn {
 }
 
 export function useGoodDollarClaim(): UseGoodDollarClaimReturn {
-  const { address } = useAccount();
+  const { address } = useAuth();
   const publicClient = usePublicClient();
-  const { data: walletClient } = useWalletClient();
+  const walletClient = useUnifiedWalletClient();
   // Use the safe wrapper that always calls the hook unconditionally
   const identitySDK = useIdentitySDKSafe();
 

--- a/apps/web/src/hooks/useGoodDollarSDK.ts
+++ b/apps/web/src/hooks/useGoodDollarSDK.ts
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect, useState, useCallback, useMemo } from "react";
-import { useAccount, usePublicClient, useWalletClient } from "wagmi";
+import { usePublicClient } from "wagmi";
 import { formatUnits } from "viem";
+import { useAuth } from "@/hooks/use-auth";
+import { useUnifiedWalletClient } from "@/hooks/use-unified-wallet-client";
 
 // Internal SDK references (not React hooks)
 let identitySDKFn: any;
@@ -28,9 +30,9 @@ try {
 
 
 export function useGoodDollarSDK() {
-  const { address } = useAccount();
+  const { address } = useAuth();
   const publicClient = usePublicClient();
-  const { data: walletClient } = useWalletClient();
+  const walletClient = useUnifiedWalletClient();
 
   const env = "production" as const;
 

--- a/apps/web/src/lib/web3auth-config.ts
+++ b/apps/web/src/lib/web3auth-config.ts
@@ -4,7 +4,7 @@ import { WEB3AUTH_NETWORK } from "@web3auth/modal";
 export const web3AuthContextConfig: Web3AuthContextConfig = {
   web3AuthOptions: {
     clientId: process.env.NEXT_PUBLIC_WEB3AUTH_CLIENT_ID!,
-    web3AuthNetwork: WEB3AUTH_NETWORK.SAPPHIRE_MAINNET,
+    web3AuthNetwork: WEB3AUTH_NETWORK.SAPPHIRE_DEVNET,
     chains: [
       {
         chainNamespace: "eip155",


### PR DESCRIPTION
- Add useUnifiedWriteContract: drop-in for wagmi useWriteContract that routes Web3Auth users through viem directly, Privy users through wagmi as before
- Add useUnifiedWalletClient: provides a viem WalletClient for both auth paths, fixing GoodDollar SDK (claim, identity) for Web3Auth users
- Migrate all 14 remaining contract-write sites to useUnifiedWriteContract
- Fix useTokenBalance, useTokenApproval, identityHook, useGoodDollarSDK to use useAuth (not useAccount) so address resolves for Web3Auth users
- Fix G$ balance display on profile page (was always empty for Web3Auth users)
- Leaderboard: hide pinned "you" row when user is already visible in top 10
- Sign-in: persist last auth provider in localStorage (never cleared on logout) so "I already have an account" opens the correct modal automatically
- Sign-in: pass disableSignup:true to Privy login to prevent accidental signups